### PR TITLE
Validate pattern variables have a named variable

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -39,68 +39,70 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(7, "The match query does not have named variables to bound the nested disjunction/negation pattern(s).");
     public static final ErrorMessage MATCH_HAS_NO_NAMED_VARIABLE =
             new ErrorMessage(8, "The match query has no named variables to retrieve.");
+    public static final ErrorMessage MATCH_PATTERN_VARIABLE_HAS_NO_NAMED_VARIABLE =
+            new ErrorMessage(9, "The pattern '%s' has no named variable.");
     public static final ErrorMessage MATCH_HAS_UNBOUNDED_NESTED_PATTERN =
-            new ErrorMessage(9, "The match query contains a nested pattern is not bounded: '%s'.");
+            new ErrorMessage(10, "The match query contains a nested pattern is not bounded: '%s'.");
     public static final ErrorMessage MISSING_MATCH_FILTER =
-            new ErrorMessage(10, "The match query cannot be constructed with NULL filter variable collection.");
+            new ErrorMessage(11, "The match query cannot be constructed with NULL filter variable collection.");
     public static final ErrorMessage EMPTY_MATCH_FILTER =
-            new ErrorMessage(11, "The match query cannot be filtered with an empty list of variables.");
+            new ErrorMessage(12, "The match query cannot be filtered with an empty list of variables.");
     public static final ErrorMessage INVALID_IID_STRING =
-            new ErrorMessage(12, "Invalid IID: '%s'. IIDs must follow the regular expression: '%s'.");
+            new ErrorMessage(13, "Invalid IID: '%s'. IIDs must follow the regular expression: '%s'.");
     public static final ErrorMessage INVALID_ATTRIBUTE_TYPE_REGEX =
-            new ErrorMessage(13, "Invalid regular expression '%s'.");
+            new ErrorMessage(14, "Invalid regular expression '%s'.");
     public static final ErrorMessage ILLEGAL_FILTER_VARIABLE_REPEATING =
-            new ErrorMessage(14, "The variable '%s' occurred more than once in match query filter.");
+            new ErrorMessage(15, "The variable '%s' occurred more than once in match query filter.");
     public static final ErrorMessage VARIABLE_OUT_OF_SCOPE_MATCH =
-            new ErrorMessage(15, "The variable '%s' is out of scope of the match query.");
+            new ErrorMessage(16, "The variable '%s' is out of scope of the match query.");
     public static final ErrorMessage VARIABLE_OUT_OF_SCOPE_DELETE =
-            new ErrorMessage(16, "The deleted variable '%s' is out of scope of the match query.");
+            new ErrorMessage(17, "The deleted variable '%s' is out of scope of the match query.");
     public static final ErrorMessage NO_VARIABLE_IN_SCOPE_INSERT =
-            new ErrorMessage(17, "None of the variables in 'insert' ('%s') is within scope of 'match' ('%s')");
+            new ErrorMessage(18, "None of the variables in 'insert' ('%s') is within scope of 'match' ('%s')");
     public static final ErrorMessage VARIABLE_NOT_NAMED =
-            new ErrorMessage(18, "The variable '%s' is not named and cannot be used as a filter for match query.");
+            new ErrorMessage(19, "The variable '%s' is not named and cannot be used as a filter for match query.");
     public static final ErrorMessage INVALID_VARIABLE_NAME =
-            new ErrorMessage(19, "The variable name '%s' is invalid; variables must match the following regular expression: '%s'.");
+            new ErrorMessage(20, "The variable name '%s' is invalid; variables must match the following regular expression: '%s'.");
     public static final ErrorMessage ILLEGAL_CONSTRAINT_REPETITION =
-            new ErrorMessage(20, "The variable '%s' contains illegally repeating constraints: '%s' and '%s'.");
+            new ErrorMessage(21, "The variable '%s' contains illegally repeating constraints: '%s' and '%s'.");
     public static final ErrorMessage MISSING_CONSTRAINT_RELATION_PLAYER =
-            new ErrorMessage(21, "A relation variable has not been provided with role players.");
+            new ErrorMessage(22, "A relation variable has not been provided with role players.");
     public static final ErrorMessage MISSING_CONSTRAINT_VALUE =
-            new ErrorMessage(22, "A value constraint has not been provided with a variable or literal value.");
+            new ErrorMessage(23, "A value constraint has not been provided with a variable or literal value.");
     public static final ErrorMessage MISSING_CONSTRAINT_PREDICATE =
-            new ErrorMessage(23, "A value constraint has not been provided with a predicate.");
+            new ErrorMessage(24, "A value constraint has not been provided with a predicate.");
     public static final ErrorMessage INVALID_CONSTRAINT_DATETIME_PRECISION =
-            new ErrorMessage(24, "Attempted to assign DateTime value of '%s' which is more precise than 1 millisecond.");
+            new ErrorMessage(25, "Attempted to assign DateTime value of '%s' which is more precise than 1 millisecond.");
     public static final ErrorMessage INVALID_DEFINE_QUERY_VARIABLE =
-            new ErrorMessage(25, "Invalid define/undefine query. User defined variables are not accepted in define/undefine query.");
+            new ErrorMessage(26, "Invalid define/undefine query. User defined variables are not accepted in define/undefine query.");
     public static final ErrorMessage INVALID_RULE_WHEN_MISSING_PATTERNS =
-            new ErrorMessage(26, "Rule '%s' 'when' has not been provided with any patterns.");
+            new ErrorMessage(27, "Rule '%s' 'when' has not been provided with any patterns.");
     public static final ErrorMessage INVALID_RULE_WHEN_NESTED_NEGATION =
-            new ErrorMessage(27, "Rule '%s' 'when' contains a nested negation.");
+            new ErrorMessage(28, "Rule '%s' 'when' contains a nested negation.");
     public static final ErrorMessage INVALID_RULE_WHEN_CONTAINS_DISJUNCTION =
-            new ErrorMessage(28, "Rule '%s' 'when' contains a disjunction.");
+            new ErrorMessage(29, "Rule '%s' 'when' contains a disjunction.");
     public static final ErrorMessage INVALID_RULE_THEN =
-            new ErrorMessage(29, "Rule '%s' 'then' '%s': must be exactly one attribute ownership, or exactly one relation.");
+            new ErrorMessage(30, "Rule '%s' 'then' '%s': must be exactly one attribute ownership, or exactly one relation.");
     public static final ErrorMessage INVALID_RULE_THEN_HAS =
-            new ErrorMessage(30, "Rule '%s' 'then' '%s': is trying to assign both an attribute type and a variable attribute value.");
+            new ErrorMessage(31, "Rule '%s' 'then' '%s': is trying to assign both an attribute type and a variable attribute value.");
     public static final ErrorMessage INVALID_RULE_THEN_VARIABLES =
-            new ErrorMessage(31, "Rule '%s' 'then' variables must be present in rule 'when'.");
+            new ErrorMessage(32, "Rule '%s' 'then' variables must be present in rule 'when'.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =
-            new ErrorMessage(32, "Invalid query containing redundant nested negations.");
+            new ErrorMessage(33, "Invalid query containing redundant nested negations.");
     public static final ErrorMessage MISSING_COMPUTE_CONDITION =
-            new ErrorMessage(33, "Missing condition(s) for 'compute '%s''. The required condition(s) are: '%s'.");
+            new ErrorMessage(34, "Missing condition(s) for 'compute '%s''. The required condition(s) are: '%s'.");
     public static final ErrorMessage INVALID_COMPUTE_METHOD_ALGORITHM =
-            new ErrorMessage(34, "Invalid algorithm for 'compute '%s''. The accepted algorithm(s) are: '%s'.");
+            new ErrorMessage(35, "Invalid algorithm for 'compute '%s''. The accepted algorithm(s) are: '%s'.");
     public static final ErrorMessage INVALID_COMPUTE_ARGUMENT =
-            new ErrorMessage(35, "Invalid argument(s) 'compute %s using %s'. The accepted argument(s) are: '%s'.");
+            new ErrorMessage(36, "Invalid argument(s) 'compute %s using %s'. The accepted argument(s) are: '%s'.");
     public static final ErrorMessage INVALID_SORTING_ORDER =
-            new ErrorMessage(36, "Invalid sorting order. Valid options: '%s' or '%s'.");
+            new ErrorMessage(37, "Invalid sorting order. Valid options: '%s' or '%s'.");
     public static final ErrorMessage INVALID_COUNT_VARIABLE_ARGUMENT =
-            new ErrorMessage(37, "Aggregate COUNT does not accept a Variable.");
+            new ErrorMessage(38, "Aggregate COUNT does not accept a Variable.");
     public static final ErrorMessage ILLEGAL_GRAMMAR =
-            new ErrorMessage(38, "Illegal grammar!");
+            new ErrorMessage(39, "Illegal grammar!");
     public static final ErrorMessage ILLEGAL_CHAR_IN_LABEL =
-            new ErrorMessage(39, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
+            new ErrorMessage(40, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
 
 
     private static final String codePrefix = "GQL";

--- a/query/TypeQLMatch.java
+++ b/query/TypeQLMatch.java
@@ -26,6 +26,7 @@ import com.vaticle.typeql.lang.common.TypeQLToken;
 import com.vaticle.typeql.lang.common.exception.ErrorMessage;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.Conjunction;
+import com.vaticle.typeql.lang.pattern.Negation;
 import com.vaticle.typeql.lang.pattern.Pattern;
 import com.vaticle.typeql.lang.pattern.variable.BoundVariable;
 import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA_SPACE;
@@ -56,6 +58,7 @@ import static com.vaticle.typeql.lang.common.exception.ErrorMessage.ILLEGAL_FILT
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_COUNT_VARIABLE_ARGUMENT;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MATCH_HAS_NO_BOUNDING_NAMED_VARIABLE;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MATCH_HAS_NO_NAMED_VARIABLE;
+import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MATCH_PATTERN_VARIABLE_HAS_NO_NAMED_VARIABLE;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MISSING_PATTERNS;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.VARIABLE_NOT_NAMED;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.VARIABLE_OUT_OF_SCOPE_MATCH;
@@ -90,12 +93,14 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
 
         hasBoundingConjunction();
         nestedPatternsAreBounded();
-        hasNamedVariable();
+        queryHasNamedVariable();
+        eachPatternVariableHasNamedVariable(conjunction.patterns());
         filtersAreInScope();
-        sortVarsArInScope();
+        sortVarsAreInScope();
 
         this.hash = Objects.hash(this.conjunction, this.modifiers);
     }
+
 
     public class Modifiers {
 
@@ -178,8 +183,20 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
         });
     }
 
-    private void hasNamedVariable() {
+    private void queryHasNamedVariable() {
         if (namedVariablesUnbound().isEmpty()) throw TypeQLException.of(MATCH_HAS_NO_NAMED_VARIABLE);
+    }
+
+    private void eachPatternVariableHasNamedVariable(List<? extends Pattern> patterns) {
+        patterns.forEach(pattern -> {
+            if (pattern.isVariable()) {
+                if (!pattern.asVariable().reference().isName() && pattern.asVariable().variables().noneMatch(constraintVar -> constraintVar.reference().isName())) {
+                    throw TypeQLException.of(MATCH_PATTERN_VARIABLE_HAS_NO_NAMED_VARIABLE.message(pattern));
+                }
+            } else {
+                eachPatternVariableHasNamedVariable(pattern.patterns());
+            }
+        });
     }
 
     private void filtersAreInScope() {
@@ -193,7 +210,7 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
         }
     }
 
-    private void sortVarsArInScope() {
+    private void sortVarsAreInScope() {
         List<UnboundVariable> sortableVars = modifiers.filter.isEmpty() ? namedVariablesUnbound() : modifiers.filter;
         if (modifiers.sorting != null && !sortableVars.contains(modifiers.sorting.var())) {
             throw TypeQLException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(modifiers.sorting.var()));

--- a/query/TypeQLMatch.java
+++ b/query/TypeQLMatch.java
@@ -189,11 +189,10 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
 
     private void eachPatternVariableHasNamedVariable(List<? extends Pattern> patterns) {
         patterns.forEach(pattern -> {
-            if (pattern.isVariable()) {
-                if (!pattern.asVariable().reference().isName() && pattern.asVariable().variables().noneMatch(constraintVar -> constraintVar.reference().isName())) {
-                    throw TypeQLException.of(MATCH_PATTERN_VARIABLE_HAS_NO_NAMED_VARIABLE.message(pattern));
-                }
-            } else {
+            if (pattern.isVariable() && !pattern.asVariable().reference().isName()
+                    && pattern.asVariable().variables().noneMatch(constraintVar -> constraintVar.reference().isName())) {
+                throw TypeQLException.of(MATCH_PATTERN_VARIABLE_HAS_NO_NAMED_VARIABLE.message(pattern));
+            } else if (!pattern.isVariable()) {
                 eachPatternVariableHasNamedVariable(pattern.patterns());
             }
         });


### PR DESCRIPTION
## What is the goal of this PR?

We can create implicit variables by omitting named variables in certain parts of a query - however doing so and leaving out ALL named variables in a pattern variable (eg. between semicolons) is meaningless and should throw an error, which is validated in this change.

## What are the changes implemented in this PR?

* all `match` patterns must contain leading `Variable`s that contain at least one named variable within itself or its constraints