### PR TITLE
Fix error messages being duplicated

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -105,7 +105,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
             new ErrorMessage(40, "'%s' is not a valid Type label. Type labels must start with a letter, and may contain only letters, numbers, '-' and '_'.");
 
 
-    private static final String codePrefix = "GQL";
+    private static final String codePrefix = "TQL";
     private static final String messagePrefix = "TypeQL Error";
 
     public ErrorMessage(int codeNumber, String messageBody) {

--- a/parser/ErrorListener.java
+++ b/parser/ErrorListener.java
@@ -74,6 +74,10 @@ public class ErrorListener extends BaseErrorListener {
         return !errors.isEmpty();
     }
 
+    public void clearErrors() {
+        errors.clear();
+    }
+
     @Override
     public String toString() {
         return errors.stream().map(SyntaxError::toString).collect(Collectors.joining("\n"));

--- a/parser/Parser.java
+++ b/parser/Parser.java
@@ -136,6 +136,7 @@ public class Parser extends TypeQLBaseVisitor {
             // DefaultErrorStrategy + LL_EXACT_AMBIG_DETECTION
             // This was not set to default parsing strategy, but it is useful
             // to produce detailed/useful error message
+            errorListener.clearErrors();
             parser.setErrorHandler(new DefaultErrorStrategy());
             parser.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
             queryContext = parserMethod.apply(parser);


### PR DESCRIPTION
## What is the goal of this PR?

Previously, when parsing a query failed with an error, on converting the resulting error object to a string, the string would contain two copies of the error message - e.g:
```
[GQL03] TypeQL Error: There is a syntax error at line 1:
match $x sb thing;
         ^
no viable alternative at input 'match $x sb'
[GQL03] TypeQL Error: There is a syntax error at line 1:
match $x sb thing;
         ^
no viable alternative at input 'match $x sb'
```
This is now fixed and error messages are no longer duplicated. (Also, the error code is now TQL)

## What are the changes implemented in this PR?

- Fix error messages being duplicated (fixes vaticle/typeql#222)
- Change error code from GQL to TQL