### PR TITLE
Allow sorting on multiple variables

### DIFF
--- a/TypeQL.java
+++ b/TypeQL.java
@@ -43,7 +43,6 @@ import com.vaticle.typeql.lang.query.TypeQLQuery;
 import com.vaticle.typeql.lang.query.TypeQLUndefine;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -100,7 +99,7 @@ public class TypeQL {
     }
 
     public static TypeQLMatch.Unfiltered match(Pattern... patterns) {
-        return match(Arrays.asList(patterns));
+        return match(list(patterns));
     }
 
     public static TypeQLMatch.Unfiltered match(List<? extends Pattern> patterns) {
@@ -138,7 +137,7 @@ public class TypeQL {
     // Pattern Builder Methods
 
     public static Conjunction<? extends Pattern> and(Pattern... patterns) {
-        return and(Arrays.asList(patterns));
+        return and(list(patterns));
     }
 
     public static Conjunction<? extends Pattern> and(List<? extends Pattern> patterns) {
@@ -146,7 +145,7 @@ public class TypeQL {
     }
 
     public static Pattern or(Pattern... patterns) {
-        return or(Arrays.asList(patterns));
+        return or(list(patterns));
     }
 
     public static Pattern or(List<Pattern> patterns) {

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -31,8 +31,8 @@ def vaticle_dependencies():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
-        tag = "2.3.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/flyingsilverfin/typeql",
+        commit = "9992011edd86cb8c636e33078b5801a78fbd89c8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -31,8 +31,8 @@ def vaticle_dependencies():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/flyingsilverfin/typeql",
-        commit = "9992011edd86cb8c636e33078b5801a78fbd89c8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/vaticle/typeql",
+        commit = "7969d446a4f739ccb82ecb93196b7d176471a066", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/parser/ErrorListener.java
+++ b/parser/ErrorListener.java
@@ -26,9 +26,10 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.vaticle.typedb.common.collection.Collections.list;
 
 /**
  * ANTLR error listener that listens for syntax errors.
@@ -54,7 +55,7 @@ public class ErrorListener extends BaseErrorListener {
     }
 
     public static ErrorListener of(String query) {
-        List<String> queryList = Arrays.asList(query.split("\n"));
+        List<String> queryList = list(query.split("\n"));
         return new ErrorListener(queryList);
     }
 

--- a/parser/Parser.java
+++ b/parser/Parser.java
@@ -327,12 +327,7 @@ public class Parser extends TypeQLBaseVisitor {
             Long offset = null, limit = null;
 
             if (ctx.modifiers().filter() != null) variables = this.visitFilter(ctx.modifiers().filter());
-            if (ctx.modifiers().sort() != null) {
-                UnboundVariable var = getVar(ctx.modifiers().sort().VAR_());
-                sorting = ctx.modifiers().sort().ORDER_() == null
-                        ? new Sortable.Sorting(var)
-                        : new Sortable.Sorting(var, TypeQLArg.Order.of(ctx.modifiers().sort().ORDER_().getText()));
-            }
+            if (ctx.modifiers().sort() != null) sorting = this.visitSort(ctx.modifiers().sort());
             if (ctx.modifiers().offset() != null) offset = getLong(ctx.modifiers().offset().LONG_());
             if (ctx.modifiers().limit() != null) limit = getLong(ctx.modifiers().limit().LONG_());
             match = new TypeQLMatch(match.conjunction(), variables, sorting, offset, limit);
@@ -380,6 +375,14 @@ public class Parser extends TypeQLBaseVisitor {
     @Override
     public List<UnboundVariable> visitFilter(TypeQLParser.FilterContext ctx) {
         return ctx.VAR_().stream().map(this::getVar).collect(toList());
+    }
+
+    @Override
+    public Sortable.Sorting visitSort(TypeQLParser.SortContext ctx) {
+        UnboundVariable[] vars = ctx.VAR_().stream().map(this::getVar).toArray(UnboundVariable[]::new);
+        return ctx.ORDER_() == null ? new Sortable.Sorting(vars) :
+                new Sortable.Sorting(vars, TypeQLArg.Order.of(ctx.ORDER_().getText()));
+
     }
 
     // COMPUTE QUERY ===========================================================

--- a/parser/Parser.java
+++ b/parser/Parser.java
@@ -379,7 +379,7 @@ public class Parser extends TypeQLBaseVisitor {
 
     @Override
     public Sortable.Sorting visitSort(TypeQLParser.SortContext ctx) {
-        UnboundVariable[] vars = ctx.VAR_().stream().map(this::getVar).toArray(UnboundVariable[]::new);
+        List<UnboundVariable> vars = ctx.VAR_().stream().map(this::getVar).collect(toList());
         return ctx.ORDER_() == null ? new Sortable.Sorting(vars) :
                 new Sortable.Sorting(vars, TypeQLArg.Order.of(ctx.ORDER_().getText()));
     }

--- a/parser/Parser.java
+++ b/parser/Parser.java
@@ -382,7 +382,6 @@ public class Parser extends TypeQLBaseVisitor {
         UnboundVariable[] vars = ctx.VAR_().stream().map(this::getVar).toArray(UnboundVariable[]::new);
         return ctx.ORDER_() == null ? new Sortable.Sorting(vars) :
                 new Sortable.Sorting(vars, TypeQLArg.Order.of(ctx.ORDER_().getText()));
-
     }
 
     // COMPUTE QUERY ===========================================================

--- a/parser/test/BUILD
+++ b/parser/test/BUILD
@@ -30,6 +30,7 @@ java_test(
         "//common:common",
         "//pattern:pattern",
         "//query:query",
+        "@vaticle_typedb_common//:common",
         "@maven//:org_hamcrest_hamcrest_library",
     ],
     size = "small",

--- a/parser/test/ParserTest.java
+++ b/parser/test/ParserTest.java
@@ -42,10 +42,10 @@ import org.junit.rules.ExpectedException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typeql.lang.TypeQL.and;
 import static com.vaticle.typeql.lang.TypeQL.define;
 import static com.vaticle.typeql.lang.TypeQL.gte;
@@ -377,7 +377,6 @@ public class ParserTest {
         TypeQLMatch apiQuery = match(var("x").has("release-date", LocalDateTime.of(1000, 11, 12, 13, 14, 15, 123450000)));
     }
 
-
     @Test
     public void testLongPredicateQuery() {
         final String query = "match $x isa movie, has tmdb-vote-count <= 400;";
@@ -391,7 +390,7 @@ public class ParserTest {
     public void testSchemaQuery() {
         final String query = "match $x plays starring:actor; sort $x asc;";
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
-        TypeQLMatch expected = match(var("x").plays("starring", "actor")).sort(Arrays.asList("x"), "asc");
+        TypeQLMatch expected = match(var("x").plays("starring", "actor")).sort(list("x"), "asc");
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -402,7 +401,7 @@ public class ParserTest {
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
         TypeQLMatch expected = match(
                 var("x").isa("movie").has("rating", var("r"))
-        ).sort(Arrays.asList("r"), "desc");
+        ).sort(list("r"), "desc");
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -424,7 +423,7 @@ public class ParserTest {
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
         TypeQLMatch expected = match(
                 var("x").isa("movie").has("rating", var("r"))
-        ).sort(Arrays.asList("r"), "desc").offset(10).limit(10);
+        ).sort(list("r"), "desc").offset(10).limit(10);
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -1130,7 +1129,7 @@ public class ParserTest {
         final String getString = "match $y isa movie;";
         List<TypeQLQuery> queries = TypeQL.parseQueries(getString).collect(toList());
 
-        assertEquals(Arrays.asList(match(var("y").isa("movie"))), queries);
+        assertEquals(list(match(var("y").isa("movie"))), queries);
     }
 
     @Test
@@ -1138,7 +1137,7 @@ public class ParserTest {
         final String insertString = "insert $x isa movie;";
         List<TypeQLQuery> queries = TypeQL.parseQueries(insertString).collect(toList());
 
-        assertEquals(Arrays.asList(insert(var("x").isa("movie"))), queries);
+        assertEquals(list(insert(var("x").isa("movie"))), queries);
     }
 
     @Test
@@ -1146,7 +1145,7 @@ public class ParserTest {
         final String insertString = " insert $x isa movie;";
         List<TypeQLQuery> queries = TypeQL.parseQueries(insertString).collect(toList());
 
-        assertEquals(Arrays.asList(insert(var("x").isa("movie"))), queries);
+        assertEquals(list(insert(var("x").isa("movie"))), queries);
     }
 
     @Test
@@ -1154,7 +1153,7 @@ public class ParserTest {
         final String insertString = "#hola\ninsert $x isa movie;";
         List<TypeQLQuery> queries = TypeQL.parseQueries(insertString).collect(toList());
 
-        assertEquals(Arrays.asList(insert(var("x").isa("movie"))), queries);
+        assertEquals(list(insert(var("x").isa("movie"))), queries);
     }
 
     @Test
@@ -1163,7 +1162,7 @@ public class ParserTest {
         final String getString = "match $y isa movie;";
         List<TypeQLQuery> queries = TypeQL.parseQueries(insertString + getString).collect(toList());
 
-        assertEquals(Arrays.asList(insert(var("x").isa("movie")), match(var("y").isa("movie"))), queries);
+        assertEquals(list(insert(var("x").isa("movie")), match(var("y").isa("movie"))), queries);
     }
 
     @Test

--- a/parser/test/ParserTest.java
+++ b/parser/test/ParserTest.java
@@ -391,7 +391,7 @@ public class ParserTest {
     public void testSchemaQuery() {
         final String query = "match $x plays starring:actor; sort $x asc;";
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
-        TypeQLMatch expected = match(var("x").plays("starring", "actor")).sort("x", "asc");
+        TypeQLMatch expected = match(var("x").plays("starring", "actor")).sort(Arrays.asList("x"), "asc");
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -402,7 +402,7 @@ public class ParserTest {
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
         TypeQLMatch expected = match(
                 var("x").isa("movie").has("rating", var("r"))
-        ).sort("r", "desc");
+        ).sort(Arrays.asList("r"), "desc");
 
         assertQueryEquals(expected, parsed, query);
     }
@@ -424,7 +424,7 @@ public class ParserTest {
         TypeQLMatch parsed = TypeQL.parseQuery(query).asMatch();
         TypeQLMatch expected = match(
                 var("x").isa("movie").has("rating", var("r"))
-        ).sort("r", "desc").offset(10).limit(10);
+        ).sort(Arrays.asList("r"), "desc").offset(10).limit(10);
 
         assertQueryEquals(expected, parsed, query);
     }

--- a/pattern/Negation.java
+++ b/pattern/Negation.java
@@ -26,7 +26,6 @@ import com.vaticle.typeql.lang.common.exception.ErrorMessage;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -57,7 +56,7 @@ public class Negation<T extends Pattern> implements Conjunctable {
 
     @Override
     public List<? extends Pattern> patterns() {
-        return Arrays.asList(pattern);
+        return list(pattern);
     }
 
     @Override

--- a/pattern/variable/BoundVariable.java
+++ b/pattern/variable/BoundVariable.java
@@ -25,11 +25,11 @@ import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.Conjunctable;
 import com.vaticle.typeql.lang.pattern.Pattern;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_CASTING;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MATCH_HAS_UNBOUNDED_NESTED_PATTERN;
@@ -84,6 +84,6 @@ public abstract class BoundVariable extends Variable implements Conjunctable {
 
     @Override
     public List<? extends Pattern> patterns() {
-        return Arrays.asList(this);
+        return list(this);
     }
 }

--- a/query/TypeQLMatch.java
+++ b/query/TypeQLMatch.java
@@ -26,7 +26,6 @@ import com.vaticle.typeql.lang.common.TypeQLToken;
 import com.vaticle.typeql.lang.common.exception.ErrorMessage;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
 import com.vaticle.typeql.lang.pattern.Conjunction;
-import com.vaticle.typeql.lang.pattern.Negation;
 import com.vaticle.typeql.lang.pattern.Pattern;
 import com.vaticle.typeql.lang.pattern.variable.BoundVariable;
 import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COMMA_SPACE;
@@ -211,8 +209,8 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
 
     private void sortVarsAreInScope() {
         List<UnboundVariable> sortableVars = modifiers.filter.isEmpty() ? namedVariablesUnbound() : modifiers.filter;
-        if (modifiers.sorting != null && !sortableVars.contains(modifiers.sorting.var())) {
-            throw TypeQLException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(modifiers.sorting.var()));
+        if (modifiers.sorting != null && Arrays.stream(modifiers.sorting.vars()).anyMatch(v -> !sortableVars.contains(v))) {
+            throw TypeQLException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(Arrays.toString(modifiers.sorting.vars())));
         }
     }
 

--- a/query/TypeQLMatch.java
+++ b/query/TypeQLMatch.java
@@ -35,7 +35,6 @@ import com.vaticle.typeql.lang.query.builder.Sortable;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -305,7 +304,7 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
         public TypeQLMatch.Filtered get(UnboundVariable var, UnboundVariable... vars) {
             List<UnboundVariable> varList = new ArrayList<>();
             varList.add(var);
-            varList.addAll(Arrays.asList(vars));
+            varList.addAll(list(vars));
             return get(varList);
         }
 

--- a/query/TypeQLMatch.java
+++ b/query/TypeQLMatch.java
@@ -209,8 +209,8 @@ public class TypeQLMatch extends TypeQLQuery implements Aggregatable<TypeQLMatch
 
     private void sortVarsAreInScope() {
         List<UnboundVariable> sortableVars = modifiers.filter.isEmpty() ? namedVariablesUnbound() : modifiers.filter;
-        if (modifiers.sorting != null && Arrays.stream(modifiers.sorting.vars()).anyMatch(v -> !sortableVars.contains(v))) {
-            throw TypeQLException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(Arrays.toString(modifiers.sorting.vars())));
+        if (modifiers.sorting != null && modifiers.sorting.vars().stream().anyMatch(v -> !sortableVars.contains(v))) {
+            throw TypeQLException.of(VARIABLE_OUT_OF_SCOPE_MATCH.message(modifiers.sorting.vars()));
         }
     }
 

--- a/query/builder/Computable.java
+++ b/query/builder/Computable.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.vaticle.typedb.common.collection.Collections.list;
+
 public interface Computable {
 
     TypeQLToken.Compute.Method method();
@@ -59,7 +61,7 @@ public interface Computable {
         default T of(String type, String... types) {
             ArrayList<String> typeList = new ArrayList<>(types.length + 1);
             typeList.add(type);
-            typeList.addAll(Arrays.asList(types));
+            typeList.addAll(list(types));
 
             return of(typeList);
         }
@@ -76,7 +78,7 @@ public interface Computable {
         default T in(String type, String... types) {
             ArrayList<String> typeList = new ArrayList<>(types.length + 1);
             typeList.add(type);
-            typeList.addAll(Arrays.asList(types));
+            typeList.addAll(list(types));
 
             return in(typeList);
         }
@@ -99,7 +101,7 @@ public interface Computable {
         default T where(U arg, U... args) {
             ArrayList<U> argList = new ArrayList<>(args.length + 1);
             argList.add(arg);
-            argList.addAll(Arrays.asList(args));
+            argList.addAll(list(args));
 
             return where(argList);
         }

--- a/query/builder/Sortable.java
+++ b/query/builder/Sortable.java
@@ -29,15 +29,14 @@ import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_SORTING_ORDER;
 
 public interface Sortable<S, O, L> {
 
-    default S sort(String first, String... next) {
-        UnboundVariable[] vars = new UnboundVariable[1 + next.length];
-        vars[0] = UnboundVariable.named(first);
-        for (int i = 1; i < next.length; i++) vars[i] = UnboundVariable.named(next[i]);
+    default S sort(String var) {
+        UnboundVariable[] vars = new UnboundVariable[] { UnboundVariable.named(var) };
         return sort(vars);
     }
 
@@ -94,10 +93,8 @@ public interface Sortable<S, O, L> {
         @Override
         public String toString() {
             StringBuilder sort = new StringBuilder();
-            sort.append(Arrays.toString(vars));
-            if (order != null) {
-                sort.append(TypeQLToken.Char.SPACE).append(order);
-            }
+            sort.append(Stream.of(vars).map(UnboundVariable::toString).reduce((a, b) -> a + ", "  + b).get());
+            if (order != null) sort.append(TypeQLToken.Char.SPACE).append(order);
             return sort.toString();
         }
 


### PR DESCRIPTION
## What is the goal of this PR?

Update the Java parser and data structures to capture multiple (ordered) sort variables. This enables https://github.com/vaticle/typedb/issues/6434.

## What are the changes implemented in this PR?

* Make `Sorting` contain `vars()` instead of `var()`