### PR TITLE
Improve error message for an invalid rule has syntax

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -84,7 +84,7 @@ public class ErrorMessage extends com.vaticle.typedb.common.exception.ErrorMessa
     public static final ErrorMessage INVALID_RULE_THEN =
             new ErrorMessage(30, "Rule '%s' 'then' '%s': must be exactly one attribute ownership, or exactly one relation.");
     public static final ErrorMessage INVALID_RULE_THEN_HAS =
-            new ErrorMessage(31, "Rule '%s' 'then' '%s': is trying to assign both an attribute type and a variable attribute value.");
+            new ErrorMessage(31, "Rule '%s' 'then' '%s' tries to assign type '%s' to variable '%s', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.");
     public static final ErrorMessage INVALID_RULE_THEN_VARIABLES =
             new ErrorMessage(32, "Rule '%s' 'then' variables must be present in rule 'when'.");
     public static final ErrorMessage REDUNDANT_NESTED_NEGATION =

--- a/pattern/schema/Rule.java
+++ b/pattern/schema/Rule.java
@@ -134,7 +134,15 @@ public class Rule implements Definable {
 
         // rule 'has' cannot assign both an attribute type and a named variable
         if (then.has().size() == 1 && then.has().get(0).type().isPresent() && then.has().get(0).attribute().isNamed()) {
-            throw TypeQLException.of(INVALID_RULE_THEN_HAS.message(label, then));
+            String attr_var = then.has().get(0).attribute().name();
+            String attr_type;
+            if (then.has().get(0).type().get().label().isPresent()) {
+                attr_type = then.has().get(0).type().get().label().get().label();
+            } else {
+                assert then.has().get(0).type().get().isNamed();
+                attr_type = then.has().get(0).type().get().name();
+            }
+            throw TypeQLException.of(INVALID_RULE_THEN_HAS.message(label, then, attr_type, attr_var));
         }
 
         // all user-written variables in the 'then' must be present in the 'when', if it exists.

--- a/pattern/schema/Rule.java
+++ b/pattern/schema/Rule.java
@@ -134,15 +134,15 @@ public class Rule implements Definable {
 
         // rule 'has' cannot assign both an attribute type and a named variable
         if (then.has().size() == 1 && then.has().get(0).type().isPresent() && then.has().get(0).attribute().isNamed()) {
-            String attr_var = then.has().get(0).attribute().name();
-            String attr_type;
+            String attrVar = then.has().get(0).attribute().name();
+            String attrType;
             if (then.has().get(0).type().get().label().isPresent()) {
-                attr_type = then.has().get(0).type().get().label().get().label();
+                attrType = then.has().get(0).type().get().label().get().label();
             } else {
                 assert then.has().get(0).type().get().isNamed();
-                attr_type = then.has().get(0).type().get().name();
+                attrType = then.has().get(0).type().get().name();
             }
-            throw TypeQLException.of(INVALID_RULE_THEN_HAS.message(label, then, attr_type, attr_var));
+            throw TypeQLException.of(INVALID_RULE_THEN_HAS.message(label, then, attrType, attrVar));
         }
 
         // all user-written variables in the 'then' must be present in the 'when', if it exists.


### PR DESCRIPTION
## What is the goal of this PR?

Users could quite sensibly think that they can assign a type to a variable attribute in a rule `then`. This is not permitted because the type of a variable in the rule `then` has already been determined by the rule `when`. Users should be clearly told what the exact issue is and how to remedy this.

## What are the changes implemented in this PR?

Tell the use the exact type and variable causing the issue and suggest to them to remove the type.
For example:
```
rule people-are-the-same:
when {
      $p isa person, has name $n;
    } then {
      $p has name $n;
    };
```
throws error:
```
[TQL31] TypeQL Error: Rule 'people-are-the-same' 'then' '$p has name $n' tries to assign type 'name' to variable 'n', but this variable already had a type assigned by the rule 'when'. Try omitting this type assignment.
```